### PR TITLE
test: ensure numba jit matches python

### DIFF
--- a/tests/functional/test_annotation_function.py
+++ b/tests/functional/test_annotation_function.py
@@ -2,6 +2,7 @@
 import pyreason as pr
 import numba
 import numpy as np
+from pyreason.scripts.numba_wrapper.numba_types.interval_type import closed
 
 
 @numba.njit
@@ -11,6 +12,17 @@ def probability_func(annotations, weights):
     union_prob = prob_A + prob_B
     union_prob = np.round(union_prob, 3)
     return union_prob, 1
+
+
+def test_probability_func_consistency():
+    """Ensure annotation function behaves the same with and without JIT."""
+    annotations = numba.typed.List()
+    annotations.append(numba.typed.List([closed(0.01, 1.0)]))
+    annotations.append(numba.typed.List([closed(0.2, 1.0)]))
+    weights = numba.typed.List([1.0, 1.0])
+    jit_res = probability_func(annotations, weights)
+    py_res = probability_func.py_func(annotations, weights)
+    assert jit_res == py_res
 
 
 def test_annotation_function():

--- a/tests/unit/dont_disable_jit/test_numba_consistency.py
+++ b/tests/unit/dont_disable_jit/test_numba_consistency.py
@@ -1,0 +1,51 @@
+import numba
+import pyreason.scripts.interpretation.interpretation as interpretation
+import pyreason.scripts.numba_wrapper.numba_types.label_type as label
+
+
+def test_satisfies_threshold_consistency():
+    """_satisfies_threshold should match between JIT and pure Python."""
+    thresh = ('greater_equal', ('number', 'total'), 4)
+    jit_res = interpretation._satisfies_threshold(10, 5, thresh)
+    py_res = interpretation._satisfies_threshold.py_func(10, 5, thresh)
+    assert jit_res == py_res
+
+
+def test_get_rule_node_clause_grounding_consistency():
+    """get_rule_node_clause_grounding outputs should match between JIT and Python."""
+    node_type = numba.types.string
+    nodes = numba.typed.List(['n1', 'n2', 'n3'])
+    groundings = numba.typed.Dict.empty(key_type=node_type, value_type=interpretation.list_of_nodes)
+    predicate_map = numba.typed.Dict.empty(key_type=label.label_type, value_type=interpretation.list_of_nodes)
+    l = label.Label('L')
+    predicate_map[l] = numba.typed.List(['n1', 'n2'])
+
+    jit_res = interpretation.get_rule_node_clause_grounding('X', groundings, predicate_map, l, nodes)
+    py_res = interpretation.get_rule_node_clause_grounding.py_func('X', groundings, predicate_map, l, nodes)
+    assert list(jit_res) == list(py_res)
+
+
+def test_get_rule_edge_clause_grounding_consistency():
+    """get_rule_edge_clause_grounding outputs should match between JIT and Python."""
+    node_type = numba.types.string
+    edge_type = numba.types.UniTuple(numba.types.string, 2)
+    nodes = numba.typed.List(['n1', 'n2'])
+    edges = numba.typed.List([('n1', 'n2'), ('n2', 'n1')])
+
+    neighbors = numba.typed.Dict.empty(key_type=node_type, value_type=interpretation.list_of_nodes)
+    neighbors['n1'] = numba.typed.List(['n2'])
+    neighbors['n2'] = numba.typed.List(['n1'])
+    reverse_neighbors = numba.typed.Dict.empty(key_type=node_type, value_type=interpretation.list_of_nodes)
+    reverse_neighbors['n1'] = numba.typed.List(['n2'])
+    reverse_neighbors['n2'] = numba.typed.List(['n1'])
+
+    groundings = numba.typed.Dict.empty(key_type=node_type, value_type=interpretation.list_of_nodes)
+    groundings_edges = numba.typed.Dict.empty(key_type=edge_type, value_type=interpretation.list_of_edges)
+    predicate_map = numba.typed.Dict.empty(key_type=label.label_type, value_type=interpretation.list_of_edges)
+    l = label.Label('L')
+
+    jit_res = interpretation.get_rule_edge_clause_grounding('X', 'Y', groundings, groundings_edges,
+                                                            neighbors, reverse_neighbors, predicate_map, l, edges)
+    py_res = interpretation.get_rule_edge_clause_grounding.py_func('X', 'Y', groundings, groundings_edges,
+                                                                    neighbors, reverse_neighbors, predicate_map, l, edges)
+    assert list(jit_res) == list(py_res)


### PR DESCRIPTION
## Summary
- add consistency tests comparing JIT-compiled functions against their pure Python versions
- cover annotation function behavior across compilation modes
- verify hello world example yields identical results with and without JIT

## Testing
- `pytest tests/unit/dont_disable_jit/test_numba_consistency.py -q`
- `pytest tests/functional/test_annotation_function.py::test_probability_func_consistency -q`
- `pytest tests/functional/test_hello_world.py::test_hello_world_consistency -q` *(fails: KeyboardInterrupt after ~108s)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a678d208321bf3b492926c182f4