### PR TITLE
Avoid infinite recursion when filtering rules

### DIFF
--- a/pyreason/scripts/utils/filter_ruleset.py
+++ b/pyreason/scripts/utils/filter_ruleset.py
@@ -8,27 +8,25 @@ def filter_ruleset(queries, rules):
     """
 
     # Helper function to collect all rules that can support making a given rule true
-    def applicable_rules_from_query(query):
-        # Start with rules that match the query directly
-        applicable = []
+    def applicable_rules_from_query(query, visited):
+        # Avoid revisiting the same predicate to prevent infinite recursion
+        if query in visited:
+            return []
+        visited.add(query)
 
+        applicable = []
         for rule in rules:
-            # If the rule's target matches the query
             if query == rule.get_target():
-                # Add the rule to the applicable set
                 applicable.append(rule)
-                # Recursively check rules that can lead up to this rule
                 for clause in rule.get_clauses():
-                    # Find supporting rules with the clause as the target
-                    supporting_rules = applicable_rules_from_query(clause[1])
-                    applicable.extend(supporting_rules)
+                    applicable.extend(applicable_rules_from_query(clause[1], visited))
 
         return applicable
 
     # Collect applicable rules for each query and eliminate duplicates
     filtered_rules = []
     for q in queries:
-        filtered_rules.extend(applicable_rules_from_query(q.get_predicate()))
+        filtered_rules.extend(applicable_rules_from_query(q.get_predicate(), set()))
 
     # Use set to avoid duplicates if a rule supports multiple queries
     return list(set(filtered_rules))

--- a/tests/test_filter_ruleset_cycle.py
+++ b/tests/test_filter_ruleset_cycle.py
@@ -1,0 +1,42 @@
+import importlib.util
+import pathlib
+
+# Load filter_ruleset without importing the full pyreason package
+SPEC_PATH = pathlib.Path(__file__).resolve().parents[1] / "pyreason" / "scripts" / "utils" / "filter_ruleset.py"
+_spec = importlib.util.spec_from_file_location("filter_ruleset", SPEC_PATH)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+filter_ruleset = _module.filter_ruleset
+
+
+class DummyRule:
+    def __init__(self, name, target, clauses):
+        self._name = name
+        self._target = target
+        self._clauses = clauses
+
+    def get_rule_name(self):
+        return self._name
+
+    def get_target(self):
+        return self._target
+
+    def get_clauses(self):
+        return self._clauses
+
+
+class DummyQuery:
+    def __init__(self, predicate):
+        self._predicate = predicate
+
+    def get_predicate(self):
+        return self._predicate
+
+
+def test_filter_ruleset_handles_cycles():
+    """Rules with circular dependencies should not cause infinite recursion."""
+    r1 = DummyRule('r1', 'a', [(None, 'b')])
+    r2 = DummyRule('r2', 'b', [(None, 'a')])
+
+    filtered = filter_ruleset([DummyQuery('a')], [r1, r2])
+    assert {r.get_rule_name() for r in filtered} == {'r1', 'r2'}


### PR DESCRIPTION
## Summary
- prevent `filter_ruleset` from revisiting the same predicate repeatedly
- add regression test to ensure cyclic rule dependencies are handled

## Testing
- `pytest tests/test_filter_ruleset_cycle.py -q`
- `pytest tests/test_rule_filtering.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3f6f40c083218611e61bfaa80d5c