### PR TITLE
test: cover update_node complement trace

### DIFF
--- a/tests/unit/disable_jit/test_reason.py
+++ b/tests/unit/disable_jit/test_reason.py
@@ -2326,6 +2326,105 @@ def test_update_node_handles_ipl_and_predicate_map(monkeypatch):
     assert len(calls) == 2
 
 
+def test_update_node_complement_records_traces(monkeypatch, helpers_fixture):
+    class SimpleInterval:
+        def __init__(self, lower=0.0, upper=1.0, static=False):
+            self.lower = lower
+            self.upper = upper
+            self.prev_lower = lower
+            self.prev_upper = upper
+            self._static = static
+
+        def copy(self):
+            return SimpleInterval(self.lower, self.upper, self._static)
+
+        def set_lower_upper(self, l, u):
+            self.prev_lower = self.lower
+            self.prev_upper = self.upper
+            self.lower = l
+            self.upper = u
+
+        def set_static(self, s):
+            self._static = s
+
+        def __eq__(self, other):
+            return self.lower == other.lower and self.upper == other.upper
+
+    class SimpleWorld:
+        def __init__(self):
+            self.world = {}
+
+        def update(self, label, bnd):
+            if label in self.world:
+                w = self.world[label]
+                lower = max(w.lower, bnd.lower)
+                upper = min(w.upper, bnd.upper)
+                w.set_lower_upper(lower, upper)
+            else:
+                self.world[label] = bnd.copy()
+
+    class _ListShim:
+        def __call__(self, iterable=()):
+            return list(iterable)
+
+        def empty_list(self, *args, **kwargs):
+            return []
+
+    interpretation = helpers_fixture.interpretation
+    label = helpers_fixture.label
+    monkeypatch.setattr(interpretation.interval, "closed", lambda l, u: SimpleInterval(l, u))
+    monkeypatch.setattr(interpretation.numba.typed, "List", _ListShim())
+    monkeypatch.setattr(interpretation.numba.types, "uint16", lambda x: x)
+
+    calls = []
+    monkeypatch.setattr(interpretation, "_update_rule_trace", lambda *a, **k: calls.append(a))
+
+    l = label.Label("L")
+    p2 = label.Label("L2")
+    p3 = label.Label("L3")
+    interpretations = {"n1": SimpleWorld()}
+    predicate_map = {}
+    ipl = [(l, p2), (p3, l)]
+
+    update_node = getattr(interpretation._update_node, "py_func", interpretation._update_node)
+    sig = inspect.signature(update_node)
+    kwargs = dict(
+        interpretations=interpretations,
+        predicate_map=predicate_map,
+        comp="n1",
+        na=(l, interpretation.interval.closed(0.1, 0.2)),
+        ipl=ipl,
+        rule_trace=[],
+        fp_cnt=0,
+        t_cnt=0,
+        static=False,
+        convergence_mode="perfect_convergence",
+        atom_trace=True,
+        save_graph_attributes_to_rule_trace=False,
+        rules_to_be_applied_trace=[],
+        idx=0,
+        facts_to_be_applied_trace=["f"],
+        rule_trace_atoms=[],
+        store_interpretation_changes=True,
+        mode="fact",
+        override=False,
+    )
+    if "num_ga" in sig.parameters:
+        kwargs["num_ga"] = [0]
+
+    updated, _ = update_node(**kwargs)
+    assert updated is True
+    assert predicate_map[l] == ["n1"]
+    assert predicate_map[p2] == ["n1"]
+    assert predicate_map[p3] == ["n1"]
+    world = interpretations["n1"].world
+    assert p2 in world and p3 in world
+    assert {entry[3] for entry in kwargs["rule_trace"]} == {l, p2, p3}
+    assert len(calls) == 3
+    if "num_ga" in sig.parameters:
+        assert kwargs["num_ga"][0] == 1
+
+
 def test_update_edge_handles_ipl_and_predicate_map(monkeypatch, helpers_fixture):
     class SimpleInterval:
         def __init__(self, lower=0.0, upper=1.0, static=False):


### PR DESCRIPTION
## Summary
- add unit test for `_update_node` complement updates with traces

## Testing
- `pytest tests/unit/disable_jit/test_reason.py::test_update_node_complement_records_traces -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd0062fa4832180ac037e2b26b22b