### PR TITLE
Clarify test hooks and add JIT unit tests to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,12 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: pytest-unit-jit
+        name: Run JIT-enabled unit tests
+        entry: bash -c 'pytest tests/unit/dont_disable_jit'
+        language: system
+        pass_filenames: false
+
       # --- Functional tests ---
       - id: pytest-functional
         name: Run functional tests

--- a/contributing.md
+++ b/contributing.md
@@ -1,25 +1,39 @@
 
+## Getting Started
+
+Install the project requirements and the pre-commit framework:
+
+```bash
+pip install -r requirements.txt
+pip install pre-commit
+```
+
 ## Setting up Pre-Commit Hooks
 
-To ensure code quality and consistency, set up the pre-commit hooks by running the following command:
+To ensure code quality and consistency, enable the pre-commit hooks:
 
 ```bash
 pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
 
-This will configure the necessary hooks to run automatically during commits and pushes.
+On every commit, the hooks will run the unit tests located in
+`tests/unit/disable_jit` and `tests/unit/dont_disable_jit`. Functional tests in
+`tests/functional` execute on every push. You can trigger all checks manually
+with `pre-commit run --all-files`.
 
-# Linting
+## Linting
 
-We are working to update the codebase to comply with the `ruff` linting rules.  Run this command to view linting: 
+We are working to update the codebase to comply with `ruff` linting rules. Run
+this command to view linting results:
+
 ```bash
 ruff check .
 ```
 
+## Running Tests Manually
 
-## Running Tests
-
-This codebase has a unit and functional test suite.  You can run the unit tests using `pytest` with the following command:
+The automated hooks cover most scenarios, but you can invoke the test suites
+directly:
 
 ```bash
 pytest tests/unit
@@ -29,3 +43,5 @@ pytest tests/unit
 pytest tests/functional
 ```
 
+Running tests locally before committing or pushing helps catch issues early and
+speeds up code review.


### PR DESCRIPTION
## Summary
- explain how pre-commit hooks run unit and functional tests
- add pre-commit hook for JIT-enabled unit tests

## Testing
- `pre-commit run --files .pre-commit-config.yaml contributing.md`

------
https://chatgpt.com/codex/tasks/task_e_68be011e8af08321b0831e4137377d4d